### PR TITLE
Add `default-signifies-exhasutive` flag to prevent default clause from automatically passing checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ mysumtype.go:18:2: exhaustiveness check failed for sum type 'MySumType': missing
 ```
 
 Adding either a `default` clause or a clause to handle `*VariantB` will cause
-exhaustive checks to pass.
+exhaustive checks to pass. To prevent `default` clauses from automatically
+passing checks, set the `-default-signifies-exhasutive=false` flag.
 
 As a special case, if the type switch statement contains a `default` clause
 that always panics, then exhaustiveness checks are still performed.

--- a/cmd/go-check-sumtype/main.go
+++ b/cmd/go-check-sumtype/main.go
@@ -12,11 +12,22 @@ import (
 
 func main() {
 	log.SetFlags(0)
+
+	defaultSignifiesExhaustive := flag.Bool(
+		"default-signifies-exhaustive",
+		true,
+		"Presence of \"default\" case in switch statements satisfies exhaustiveness, if all members are not listed.",
+	)
+
 	flag.Parse()
-	if len(flag.Args()) < 1 {
+	if flag.NArg() < 1 {
 		log.Fatalf("Usage: sumtype <packages>\n")
 	}
-	args := os.Args[1:]
+	args := os.Args[flag.NFlag()+1:]
+
+	config := gochecksumtype.Config{
+		DefaultSignifiesExhaustive: *defaultSignifiesExhaustive,
+	}
 
 	conf := &packages.Config{
 		Mode: packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedTypes | packages.NeedTypesSizes |
@@ -37,7 +48,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if errs := gochecksumtype.Run(pkgs); len(errs) > 0 {
+	if errs := gochecksumtype.Run(pkgs, config); len(errs) > 0 {
 		var list []string
 		for _, err := range errs {
 			list = append(list, err.Error())

--- a/config.go
+++ b/config.go
@@ -1,0 +1,5 @@
+package gochecksumtype
+
+type Config struct {
+	DefaultSignifiesExhaustive bool
+}

--- a/run.go
+++ b/run.go
@@ -3,7 +3,7 @@ package gochecksumtype
 import "golang.org/x/tools/go/packages"
 
 // Run sumtype checking on the given packages.
-func Run(pkgs []*packages.Package) []error {
+func Run(pkgs []*packages.Package, config Config) []error {
 	var errs []error
 
 	decls, err := findSumTypeDecls(pkgs)
@@ -18,7 +18,7 @@ func Run(pkgs []*packages.Package) []error {
 	}
 
 	for _, pkg := range pkgs {
-		if pkgErrs := check(pkg, defs); pkgErrs != nil {
+		if pkgErrs := check(pkg, defs, config); pkgErrs != nil {
 			errs = append(errs, pkgErrs...)
 		}
 	}


### PR DESCRIPTION
Addresses #10 by adding a `default-signifies-exhasutive` flag that configures checks to ignore `default` clauses. This flag defaults to `true` to preserve existing behaviour.