### PR TITLE
refactor: simplify package setup in tests

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -26,8 +26,7 @@ func main() {
 	}
 }
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: true})
 	assert.Equal(t, 1, len(errs))
@@ -57,8 +56,7 @@ func main() {
 	}
 }
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: true})
 	assert.Equal(t, 1, len(errs))
@@ -88,8 +86,7 @@ func main() {
 	}
 }
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: true})
 	assert.Equal(t, 1, len(errs))
@@ -119,8 +116,7 @@ func main() {
 	}
 }
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: true})
 	assert.Equal(t, 0, len(errs))
@@ -149,8 +145,7 @@ func main() {
 	}
 }
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: true})
 	assert.Equal(t, 0, len(errs))
@@ -179,8 +174,7 @@ func main() {
 	}
 }
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: false})
 	assert.Equal(t, 1, len(errs))
@@ -198,8 +192,7 @@ type T interface {}
 
 func main() {}
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: true})
 	assert.Equal(t, 1, len(errs))
@@ -217,8 +210,7 @@ type T struct {}
 
 func main() {}
 `
-	tmpdir, pkgs := setupPackages(t, code)
-	defer teardownPackage(t, tmpdir)
+	pkgs := setupPackages(t, code)
 
 	errs := Run(pkgs, Config{DefaultSignifiesExhaustive: true})
 	assert.Equal(t, 1, len(errs))

--- a/help_test.go
+++ b/help_test.go
@@ -1,7 +1,6 @@
 package gochecksumtype
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,26 +8,16 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-func setupPackages(t *testing.T, code string) (string, []*packages.Package) {
-	tmpdir, err := ioutil.TempDir("", "go-test-sumtype-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	srcPath := filepath.Join(tmpdir, "src.go")
-	if err := ioutil.WriteFile(srcPath, []byte(code), 0600); err != nil {
+func setupPackages(t *testing.T, code string) []*packages.Package {
+	srcPath := filepath.Join(t.TempDir(), "src.go")
+	if err := os.WriteFile(srcPath, []byte(code), 0600); err != nil {
 		t.Fatal(err)
 	}
 	pkgs, err := tycheckAll([]string{srcPath})
 	if err != nil {
 		t.Fatal(err)
 	}
-	return tmpdir, pkgs
-}
-
-func teardownPackage(t *testing.T, dir string) {
-	if err := os.RemoveAll(dir); err != nil {
-		t.Fatal(err)
-	}
+	return pkgs
 }
 
 func tycheckAll(args []string) ([]*packages.Package, error) {


### PR DESCRIPTION
This PR simplifies package setup in tests by removing temporary directory management and using [`T.TempDir`](https://pkg.go.dev/testing#T.TempDir).